### PR TITLE
DEV-1057 Migrate AvatarImageFallback component to ui-shared-components 

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -4,5 +4,6 @@ angular.module('otr-ui-shared-components', [
     'angucomplete-alt',
     'otrBackendService',
     'otr-ui-shared-components.tpls',
-    'ui.bootstrap'
+    'ui.bootstrap',
+    'ngLetterAvatar'
 ]);

--- a/app/components/app-avatar-image-fallback.component.scss
+++ b/app/components/app-avatar-image-fallback.component.scss
@@ -9,7 +9,7 @@
     width: 72px;
 }
 
-.app-avatar-image__default-user {
+.app-avatar-image-fallback__default-user {
     line-height: 2em;
     text-align: center;
     height: 62px;

--- a/app/components/app-avatar-image-fallback.component.scss
+++ b/app/components/app-avatar-image-fallback.component.scss
@@ -1,0 +1,23 @@
+.fallback {
+    background: #d6dbe7;
+    border: 5px solid #fff;
+    border-radius: 50%;
+    height: 72px;
+    min-height: 72px;
+    min-width: 72px;
+    object-fit: cover;
+    width: 72px;
+}
+
+.app-avatar-image {
+    line-height: 2em;
+    text-align: center;
+    height: 62px;
+    width: 62px;
+    border-radius: 50%;
+    font-size: 39px;
+    display: flex !important;
+    justify-content: center;
+    align-items: center;
+    color: #FFFFFF;
+}

--- a/app/components/app-avatar-image-fallback.component.scss
+++ b/app/components/app-avatar-image-fallback.component.scss
@@ -1,4 +1,4 @@
-.fallback {
+.app-avatar-image-fallback__default {
     background: #d6dbe7;
     border: 5px solid #fff;
     border-radius: 50%;
@@ -9,7 +9,7 @@
     width: 72px;
 }
 
-.app-avatar-image {
+.app-avatar-image__default-user {
     line-height: 2em;
     text-align: center;
     height: 62px;

--- a/app/components/app-toggle-card.component.scss
+++ b/app/components/app-toggle-card.component.scss
@@ -5,6 +5,8 @@
 }
 
 .app-toggle-card {
+    cursor: none;
+
     &__sub-title {
         padding-right: 10px;
         font-size: 14px;

--- a/app/components/avatar-image-fallback/avatar-image-fallback.component.html
+++ b/app/components/avatar-image-fallback/avatar-image-fallback.component.html
@@ -1,7 +1,7 @@
 <img 
     ng-src="{{ vm.src }}" 
     ng-class="vm.imageClass" 
-    ng-show="vm.isProfilePictureShowing()"/>
+    ng-show="vm.src"/>
 
 <ng-letter-avatar
     data="{{ vm.name }}"
@@ -11,5 +11,5 @@
     width="62"
     fontWeight="500"
     fontFamily="Helvetica"
-    ng-show="!vm.isProfilePictureShowing()">
+    ng-show="!vm.src">
 </ng-letter-avatar>

--- a/app/components/avatar-image-fallback/avatar-image-fallback.component.html
+++ b/app/components/avatar-image-fallback/avatar-image-fallback.component.html
@@ -1,0 +1,15 @@
+<img 
+    ng-src="{{ vm.src }}" 
+    ng-class="vm.imageClass" 
+    ng-show="vm.isProfilePictureShowing()"/>
+
+<ng-letter-avatar
+    data="{{ vm.name }}"
+    shape="round"
+    charCount="{{vm.charCount}}"
+    height="62"
+    width="62"
+    fontWeight="500"
+    fontFamily="Helvetica"
+    ng-show="!vm.isProfilePictureShowing()">
+</ng-letter-avatar>

--- a/app/components/avatar-image-fallback/avatar-image-fallback.component.ts
+++ b/app/components/avatar-image-fallback/avatar-image-fallback.component.ts
@@ -19,28 +19,24 @@ class AvatarImageFallback implements AvatarImageFallbackBindings {
     constructor(private $element) {}
 
     $onInit() {
-        this.imageClass = this.avatarClass ? this.avatarClass : 'fallback';
+        this.imageClass = this.avatarClass
+            ? this.avatarClass
+            : 'app-avatar-image-fallback__default';
         this.setCharCount();
 
         this.$element.find('img').bind('error', () => {
             const appColors = ['#007BE3', '#FFC715', '#00D6B2', '#FF4848', '#385064'];
             const defaultFallback = angular
                 .element(document.createElement('i'))
-                .addClass(`fas fa-user app-avatar-image ${this.avatarClass}`)
+                .addClass(
+                    `fas fa-user app-avatar-image__default-user ${this.avatarClass}`
+                )
                 .css({
                     background: appColors[Math.floor(Math.random() * appColors.length)]
                 });
             this.$element.parent().prepend(defaultFallback);
             this.$element.remove();
         });
-    }
-
-    isProfilePictureShowing() {
-        if (!this.src || this.src.includes('default-user')) {
-            return false;
-        } else {
-            return true;
-        }
     }
 
     setCharCount() {

--- a/app/components/avatar-image-fallback/avatar-image-fallback.component.ts
+++ b/app/components/avatar-image-fallback/avatar-image-fallback.component.ts
@@ -29,7 +29,7 @@ class AvatarImageFallback implements AvatarImageFallbackBindings {
             const defaultFallback = angular
                 .element(document.createElement('i'))
                 .addClass(
-                    `fas fa-user app-avatar-image__default-user ${this.avatarClass}`
+                    `fas fa-user app-avatar-image-fallback__default-user ${this.avatarClass}`
                 )
                 .css({
                     background: appColors[Math.floor(Math.random() * appColors.length)]

--- a/app/components/avatar-image-fallback/avatar-image-fallback.component.ts
+++ b/app/components/avatar-image-fallback/avatar-image-fallback.component.ts
@@ -1,0 +1,65 @@
+import angular from 'angular';
+
+interface AvatarImageFallbackBindings {
+    src?: string;
+    avatarClass?: string;
+    name?: string;
+}
+
+class AvatarImageFallback implements AvatarImageFallbackBindings {
+    // bindings
+    src?: string;
+    avatarClass?: string;
+    name?: string;
+
+    // interface
+    imageClass!: string;
+    charCount!: number;
+
+    constructor(private $element) {}
+
+    $onInit() {
+        this.imageClass = this.avatarClass ? this.avatarClass : 'fallback';
+        this.setCharCount();
+
+        this.$element.find('img').bind('error', () => {
+            const appColors = ['#007BE3', '#FFC715', '#00D6B2', '#FF4848', '#385064'];
+            const defaultFallback = angular
+                .element(document.createElement('i'))
+                .addClass(`fas fa-user app-avatar-image ${this.avatarClass}`)
+                .css({
+                    background: appColors[Math.floor(Math.random() * appColors.length)]
+                });
+            this.$element.parent().prepend(defaultFallback);
+            this.$element.remove();
+        });
+    }
+
+    isProfilePictureShowing() {
+        if (!this.src || this.src.includes('default-user')) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    setCharCount() {
+        if (this.name) {
+            this.charCount = this.name.includes(' ') ? 2 : 1;
+        }
+    }
+}
+
+angular.module('otr-ui-shared-components').component('avatarImageFallback', {
+    templateUrl:
+        'app/components/avatar-image-fallback/avatar-image-fallback.component.html',
+    controller: AvatarImageFallback,
+    bindings: {
+        src: '<',
+        avatarClass: '@',
+        name: '@'
+    },
+    controllerAs: 'vm'
+});
+
+AvatarImageFallback.$inject = ['$element'];

--- a/app/components/toggle-card/app-toggle-card.component.html
+++ b/app/components/toggle-card/app-toggle-card.component.html
@@ -1,5 +1,5 @@
 <div
-    class="app-stat-card"
+    class="app-stat-card app-toggle-card"
     ng-class="{
         'toggle-error-red': vm.isEnabled,
         'toggle-success-green': !vm.isEnabled

--- a/index-test.html
+++ b/index-test.html
@@ -105,7 +105,7 @@
               console.log($rootScope.isIconShowing)
             }
 
-            $rootScope.profileImageUrl = "https://off-the-record-service.s3.amazonaws.com/private/clients/profile-pictures/383297.jpeg?AWSAccessKeyId=AKIAIJNV2QCSYMKVDEKQ&Expires=1656004212&Signature=SipY0B8QCnjOoo8jALMJsUT3vAE%3D"
+            $rootScope.profileImageUrl = "https://off-the-record-service.s3.amazonaws.com/private/clients/profile-pictures/383297.jpeg?AWSAccessKeyId=AKIAIJNV2QCSYMKVDEKQ&Expires=1656089733&Signature=LvRn%2BEDowvwl6JxS138HIeMsbY0%3D"
             $rootScope.name = "James Smith"
             $rootScope.avatarClass = "customer"
             $rootScope.defaultUserProfileImage = "https://s3.amazonaws.com/otr-assets/img/icons/default-user.png"
@@ -157,10 +157,9 @@
 
       .customer {
         border-radius: 50%;
-        height: 72px;
+        height: 62px;
         object-fit: cover;
-        padding: 5px;
-        width: 72px;
+        width: 62px;
       }
 
       .image-fallback-group {
@@ -303,7 +302,6 @@
         </avatar-image-fallback>
         <!-- use case: default profile image is used -->
         <avatar-image-fallback
-            src="defaultUserProfileImage"
             name="George Martin">
         </avatar-image-fallback>
         <!-- use case: facebook profile picture is used -->

--- a/index-test.html
+++ b/index-test.html
@@ -36,6 +36,7 @@
     <script src="node_modules/angular-ui-bootstrap/dist/ui-bootstrap-tpls.js"></script>
     <script src="node_modules/angular-animate/angular-animate.min.js"></script>
     <script src="dist/index.js"></script>
+    <script src="node_modules/ngletteravatar/dist/ngletteravatar.min.js"></script>
     <link
       rel="stylesheet"
       href="https://pro.fontawesome.com/releases/v5.5.0/css/all.css"
@@ -103,6 +104,13 @@
               $rootScope.isIconShowing = "false";
               console.log($rootScope.isIconShowing)
             }
+
+            $rootScope.profileImageUrl = "https://off-the-record-service.s3.amazonaws.com/private/clients/profile-pictures/383297.jpeg?AWSAccessKeyId=AKIAIJNV2QCSYMKVDEKQ&Expires=1656004212&Signature=SipY0B8QCnjOoo8jALMJsUT3vAE%3D"
+            $rootScope.name = "James Smith"
+            $rootScope.avatarClass = "customer"
+            $rootScope.defaultUserProfileImage = "https://s3.amazonaws.com/otr-assets/img/icons/default-user.png"
+            $rootScope.facebookProfilePicture = "https://graph.facebook.com/v2.5/10155312614059658/picture?height=961"
+            $rootScope.brokenProfileImageUrl = "https://off-the-record-service.s3.amazonaws.com/private/clients/profile-pictures/383297.jpeg?AWSAccessKeyId=AKIAIJNV2QCSYMKVDEKQ&Expires=1656004212&Signature=SipY0B8QCnjOoo8jALMJsUT3vAE%3"
           }, 
         ]);
     </script>
@@ -145,6 +153,21 @@
       button {
         height: min-content;
         margin: auto 0;
+      }
+
+      .customer {
+        border-radius: 50%;
+        height: 72px;
+        object-fit: cover;
+        padding: 5px;
+        width: 72px;
+      }
+
+      .image-fallback-group {
+        display: flex;
+        flex-direction: row;
+        gap: 5px;
+        align-items: center;
       }
     </style>
     <div>
@@ -259,16 +282,42 @@
         </div>
         <button ng-click="changeMessage()">Toggle Card</button>
     </div>
-
-    <h3>Star Rating Display</h3>
-    <app-star-rating-display rating="1" color="#ff595e"></app-star-rating-display>
-    <br/>
-    <app-star-rating-display rating="2"></app-star-rating-display>
-    <br/>
-    <app-star-rating-display rating="3" color="#8ac926"></app-star-rating-display>
-    <br/>
-    <app-star-rating-display rating="4" color="#1982c4"></app-star-rating-display>
-    <br/>
-    <app-star-rating-display rating="5" color="#6a4c93"></app-star-rating-display>
+    <div class="section">
+        <h3>Star Rating Display</h3>
+        <app-star-rating-display rating="1" color="#ff595e"></app-star-rating-display>
+        <br/>
+        <app-star-rating-display rating="2"></app-star-rating-display>
+        <br/>
+        <app-star-rating-display rating="3" color="#8ac926"></app-star-rating-display>
+        <br/>
+        <app-star-rating-display rating="4" color="#1982c4"></app-star-rating-display>
+        <br/>
+        <app-star-rating-display rating="5" color="#6a4c93"></app-star-rating-display>
+    </div>
+    <h3>Avatar Image Fallback</h3>
+    <div class="section image-fallback-group">
+        <avatar-image-fallback
+            src="profileImageUrl"
+            avatar-class="{{avatarClass}}"
+            name="{{name}}">
+        </avatar-image-fallback>
+        <!-- use case: default profile image is used -->
+        <avatar-image-fallback
+            src="defaultUserProfileImage"
+            name="George Martin">
+        </avatar-image-fallback>
+        <!-- use case: facebook profile picture is used -->
+        <avatar-image-fallback
+            src="facebookProfileImage"
+            avatar-class="customer"
+            name="Earl Benz">
+        </avatar-image-fallback>
+        <!-- use case: img tags that throw an error -->
+        <span>
+          <avatar-image-fallback
+              src="brokenProfileImageUrl"
+              name="Shaun Kent"></avatar-image-fallback>
+        </span>
+    </div>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@otr-app/ui-shared-components",
-  "version": "1.0.10",
+  "version": "1.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@otr-app/ui-shared-components",
-      "version": "1.0.10",
+      "version": "1.0.13",
       "license": "ISC",
       "dependencies": {
         "angucomplete-alt": "3.0.0"
@@ -43,6 +43,7 @@
         "bootstrap": "~3.3.2",
         "fuse.js": ">= 6.4.6 || < 7.0.0",
         "lodash": ">= 4.17.21 || < 5.0.0",
+        "ngletteravatar": "4.0.4",
         "pdfjs-dist": "2.5.207"
       }
     },
@@ -6074,6 +6075,12 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "node_modules/ngletteravatar": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/ngletteravatar/-/ngletteravatar-4.0.4.tgz",
+      "integrity": "sha512-1fILuiEqIRjakEwylhySwcNA5RkhQ03BfZ5K5O6l7p7PLBXSgrUESJH+hVEpWKHVN/wUlP+ZbauKXpRcNhnmlg==",
+      "peer": true
     },
     "node_modules/node-gyp": {
       "version": "7.1.2",
@@ -13949,6 +13956,12 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "ngletteravatar": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/ngletteravatar/-/ngletteravatar-4.0.4.tgz",
+      "integrity": "sha512-1fILuiEqIRjakEwylhySwcNA5RkhQ03BfZ5K5O6l7p7PLBXSgrUESJH+hVEpWKHVN/wUlP+ZbauKXpRcNhnmlg==",
+      "peer": true
     },
     "node-gyp": {
       "version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otr-app/ui-shared-components",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Module for shared components across OTR sites",
   "files": [
     "/dist"
@@ -54,6 +54,7 @@
     "bootstrap": "~3.3.2",
     "fuse.js": ">= 6.4.6 || < 7.0.0",
     "lodash": ">= 4.17.21 || < 5.0.0",
+    "ngletteravatar": "4.0.4",
     "pdfjs-dist": "2.5.207"
   }
 }


### PR DESCRIPTION
https://offtherecord.atlassian.net/browse/DEV-1057

<img width="276" alt="imagefallback" src="https://user-images.githubusercontent.com/82499628/175395699-4ff91d11-42c2-44e1-913d-2c533e97f12e.PNG">

**Migrated avatar image fallback component to ui-shared-components library**

Bindings: 
- **src:** profileImageUrl (string) optional
- **avatar-class:** CSS class name (string) optional
- **name:** (string) optional

**Areas of opportunity:**

<img width="230" alt="imagefallback2" src="https://user-images.githubusercontent.com/82499628/175396519-1518a62e-edac-4a3e-9372-dc6c3fd39e82.PNG">

- Note the function above looks for the value of `default-user`  in the src; it may be better to deal with this in the parent application instead of the component.

 