### PR TITLE
V2 Avatar image fallback component

### DIFF
--- a/app/components/avatar-image-fallback/app-avatar-image-fallback.component.html
+++ b/app/components/avatar-image-fallback/app-avatar-image-fallback.component.html
@@ -8,8 +8,9 @@
         data="{{ vm.name }}"
         shape="round"
         charCount="{{vm.charCount}}"
-        height="62"
-        width="62"
+        height="{{ vm.avatarSize }}"
+        width="{{ vm.avatarSize }}"
+        fontSize="{{ vm.fontSize }}"
         fontWeight="500"
         fontFamily="Helvetica">
     </ng-letter-avatar>

--- a/app/components/avatar-image-fallback/app-avatar-image-fallback.component.ts
+++ b/app/components/avatar-image-fallback/app-avatar-image-fallback.component.ts
@@ -4,6 +4,8 @@ interface AvatarImageFallbackBindings {
     src?: string;
     avatarClass?: string;
     name?: string;
+    avatarSize?: number;
+    fontSize?: number;
 }
 
 class AppAvatarImageFallback implements AvatarImageFallbackBindings {
@@ -11,6 +13,8 @@ class AppAvatarImageFallback implements AvatarImageFallbackBindings {
     src?: string;
     avatarClass?: string;
     name?: string;
+    avatarSize?: number;
+    fontSize?: number;
 
     // interface
     imageClass!: string;
@@ -23,6 +27,8 @@ class AppAvatarImageFallback implements AvatarImageFallbackBindings {
         this.imageClass = this.avatarClass
             ? this.avatarClass
             : 'app-avatar-image-fallback__default';
+        this.avatarSize = this.avatarSize || 62;
+        this.fontSize = this.fontSize || 30;
 
         this.setCharCount();
         this.setLetterProfileAvatar();
@@ -65,7 +71,9 @@ angular.module('otr-ui-shared-components').component('appAvatarImageFallback', {
     bindings: {
         src: '<',
         avatarClass: '@',
-        name: '@'
+        name: '@',
+        avatarSize: '<',
+        fontSize: '<'
     },
     controllerAs: 'vm'
 });

--- a/index-test.html
+++ b/index-test.html
@@ -302,7 +302,10 @@
             <!-- use case: default profile image is used -->
             <app-avatar-image-fallback
                 src="brokenProfileImage"
-                name="George Martin">
+                name="George Martin"
+                avatar-size="55"
+                font-size="15"
+                >
             </app-avatar-image-fallback>
             <!-- use case: facebook profile picture is used -->
             <app-avatar-image-fallback

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otr-app/ui-shared-components",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Module for shared components across OTR sites",
   "files": [
     "/dist"


### PR DESCRIPTION
- adds functionality to allow user to set height and width of ng-letter-avatar; if no height and width are selected than 62px is set as default
- add functionality for user to change the font-size of ng-letter-avatar; if no font-size is set than 30px is the default