### PR TITLE
Fix cursor disappearing when hovering toggle card 

### DIFF
--- a/app/components/app-toggle-card.component.scss
+++ b/app/components/app-toggle-card.component.scss
@@ -5,7 +5,7 @@
 }
 
 .app-toggle-card {
-    cursor: none;
+    cursor: default;
 
     &__sub-title {
         padding-right: 10px;
@@ -93,4 +93,8 @@
 .toggle-error-red {
     color: red;
     border-color: red;
+}
+
+.clickable {
+    cursor: pointer;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otr-app/ui-shared-components",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Module for shared components across OTR sites",
   "files": [
     "/dist"


### PR DESCRIPTION
this changes the css cursor value from cursor: none => cursor: default
also adds class clickable