### PR TITLE
DEV-1589 Add new button card component

### DIFF
--- a/app/components.ts
+++ b/app/components.ts
@@ -7,6 +7,7 @@ import './components/app-pdf-image-preview.component.scss';
 import './components/app-dropdown.component.scss';
 import './components/app-payments.component.scss';
 import './components/app-credit-card-form.component.scss';
+import './components/app-button-card.component.scss';
 
 import './directives/app-fuse-highlight.directive.ts';
 import './components/stat-card/app-stat-card.component.ts';
@@ -21,6 +22,7 @@ import './components/star-rating-display/app-star-rating-display.component.ts';
 import './components/payment-logo/payment-logos.component.ts';
 import './components/select-payment/select-payment.component';
 import './components/credit-card-form/credit-card-form.component';
+import './components/button-card/app-button-card.component';
 
 // services
 import './services/payments.service';

--- a/app/components/_vars.scss
+++ b/app/components/_vars.scss
@@ -20,6 +20,15 @@ $appFusionPurple: #5d62b5;
 }
 
 // utility classes
+
+.cursor-default {
+    cursor: default !important;
+}
+
+.clickable {
+    cursor: pointer;
+}
+
 .margin-bottom-20 {
     margin-bottom: 20px;
 }
@@ -87,7 +96,6 @@ $appFusionPurple: #5d62b5;
 %otr-button {
     border: 1px solid transparent;
     border-radius: 4px;
-    cursor: pointer;
     display: inline-block;
     font-family: sans-serif;
     font-size: 16px;

--- a/app/components/_vars.scss
+++ b/app/components/_vars.scss
@@ -1,7 +1,25 @@
-.position-relative {
-        position: relative !important;
+// colors
+$conversationDarkGray: #222;
+$appDefaultBlue: #007be3;
+$appFusionYellow: #ffc533;
+$appFusionTeal: #2ac3be;
+$appFusionRed: #f2726f;
+$appFusionPurple: #5d62b5;
+
+// Layout
+.vertical-center {
+    margin: 0;
+    position: relative;
+    top: 50%;
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
 }
-    
+
+.position-relative {
+    position: relative !important;
+}
+
+// utility classes
 .margin-bottom-20 {
     margin-bottom: 20px;
 }
@@ -31,47 +49,11 @@
 }
 
 .color-primary {
-    color: #007be3;
+    color: $appDefaultBlue;
 }
 
 .font-size-body-xs {
     font-size: 12px;
-}
-
-%otr-button {
-    border: 1px solid transparent;
-    border-radius: 4px;
-    cursor: pointer;
-    display: inline-block;
-    font-family: sans-serif;
-    font-size: 16px;
-    font-weight: 600;
-    line-height: 1.42857143;
-    margin-bottom: 0;
-    padding: 12px 15px;
-    position: relative;
-    text-align: center;
-    touch-action: manipulation;
-    user-select: none;
-    vertical-align: middle;
-    white-space: nowrap;
-    z-index: 2;
-}
-    
-.otr-button--primary {
-    @extend %otr-button;
-    
-    background-color: #007be3;
-    color: #fff;
-    
-    &:hover,
-    &:active {
-        background-color: darken(#007be3, 10%);
-    }
-    
-    &:disabled {
-        background-color: #717d96;
-    }
 }
 
 .fa-angle-down,
@@ -100,3 +82,153 @@
 .img-fit--contain {
     object-fit: contain;
 }
+
+// OTR Button
+%otr-button {
+    border: 1px solid transparent;
+    border-radius: 4px;
+    cursor: pointer;
+    display: inline-block;
+    font-family: sans-serif;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.42857143;
+    margin-bottom: 0;
+    padding: 12px 15px;
+    position: relative;
+    text-align: center;
+    touch-action: manipulation;
+    user-select: none;
+    vertical-align: middle;
+    white-space: nowrap;
+    z-index: 2;
+}
+
+.extend-otr-button {
+    @extend %otr-button;
+}
+
+.otr-button--default {
+    @extend %otr-button;
+
+    background-color: $appDefaultBlue;
+    color: #fff;
+
+    &:hover,
+    &:active {
+        background-color: darken($appDefaultBlue, 10%);
+    }
+
+    &:disabled {
+        background-color: #717d96;
+    }
+}
+
+.otr-button--fusion {    
+    &-yellow {
+        @extend %otr-button;
+        background-color: $appFusionYellow;
+        color: #fff;
+
+        &:hover,
+        &:active {
+            background-color: darken($appFusionYellow, 10%);
+        }
+
+        &:disabled {
+            background-color: #717d96;
+        }
+    }
+
+    &-teal {
+        @extend %otr-button;
+        background-color: $appFusionTeal;
+        color: #fff;
+
+        &:hover,
+        &:active {
+            background-color: darken($appFusionTeal, 10%);
+        }
+
+        &:disabled {
+            background-color: #717d96;
+        }
+    }
+
+    &-red {
+        @extend %otr-button;
+        background-color: $appFusionRed;
+        color: #fff;
+
+        &:hover,
+        &:active {
+            background-color: darken($appFusionRed, 10%);
+        }
+
+        &:disabled {
+            background-color: #717d96;
+        }
+    }
+
+    &-purple {
+        @extend %otr-button;
+        background-color: $appFusionPurple;
+        color: #fff;
+
+        &:hover,
+        &:active {
+            background-color: darken($appFusionPurple, 10%);
+        }
+
+        &:disabled {
+            background-color: #717d96;
+        }
+    }
+}
+
+// Stat/button/toggle card themes
+.default {
+    color: $appDefaultBlue;
+    border-left-color: $appDefaultBlue;
+
+        &--selected {
+        color: $appDefaultBlue;
+        border-color: $appDefaultBlue;
+        }
+    }
+
+    .fusion-yellow {
+        color: $appFusionYellow;
+        border-left-color: $appFusionYellow;
+
+        &--selected {
+        border-color: $appFusionYellow;
+        }
+    }
+
+    .fusion-teal {
+        color: $appFusionTeal;
+        border-left-color: $appFusionTeal;
+
+        &--selected {
+        border-color: $appFusionTeal;
+        }
+    }
+
+    .fusion-red {
+        color: $appFusionRed;
+        border-left-color: $appFusionRed;
+
+        &--selected {
+        border-color: $appFusionRed;
+        }
+    }
+
+    .fusion-purple {
+        color: $appFusionPurple;
+        border-left-color: $appFusionPurple;
+
+        &--selected {
+        border-color: $appFusionPurple;
+        }
+    }

--- a/app/components/_vars.scss
+++ b/app/components/_vars.scss
@@ -5,15 +5,9 @@ $appFusionYellow: #ffc533;
 $appFusionTeal: #2ac3be;
 $appFusionRed: #f2726f;
 $appFusionPurple: #5d62b5;
+$appNeutralBlue: #717d96;
 
 // Layout
-.vertical-center {
-    margin: 0;
-    position: relative;
-    top: 50%;
-    -ms-transform: translateY(-50%);
-    transform: translateY(-50%);
-}
 
 .position-relative {
     position: relative !important;
@@ -128,7 +122,7 @@ $appFusionPurple: #5d62b5;
     }
 
     &:disabled {
-        background-color: #717d96;
+        background-color: $appNeutralBlue;
     }
 }
 
@@ -144,7 +138,7 @@ $appFusionPurple: #5d62b5;
         }
 
         &:disabled {
-            background-color: #717d96;
+            background-color: $appNeutralBlue;
         }
     }
 
@@ -159,7 +153,7 @@ $appFusionPurple: #5d62b5;
         }
 
         &:disabled {
-            background-color: #717d96;
+            background-color: $appNeutralBlue;
         }
     }
 
@@ -174,7 +168,7 @@ $appFusionPurple: #5d62b5;
         }
 
         &:disabled {
-            background-color: #717d96;
+            background-color: $appNeutralBlue;
         }
     }
 
@@ -189,7 +183,7 @@ $appFusionPurple: #5d62b5;
         }
 
         &:disabled {
-            background-color: #717d96;
+            background-color: $appNeutralBlue;
         }
     }
 }

--- a/app/components/app-button-card.component.scss
+++ b/app/components/app-button-card.component.scss
@@ -1,0 +1,24 @@
+@import'_vars.scss';
+
+.app-button-card {
+    &__message {
+        color: $conversationDarkGray;
+    }
+
+    &__stat-icon {
+        color: #dddfeb;
+        font-size: 33px;
+        padding-top: 5px;
+    }
+
+    &__stat-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+    }
+
+    &__button {
+        padding: 7px 12px;
+    }
+}

--- a/app/components/app-button-card.component.scss
+++ b/app/components/app-button-card.component.scss
@@ -1,6 +1,11 @@
 @import'_vars.scss';
 
 .app-button-card {
+    &__title-layout {
+        display: flex;
+        gap: 10px;
+    }
+
     &__message {
         color: $conversationDarkGray;
     }

--- a/app/components/app-stat-card.component.scss
+++ b/app/components/app-stat-card.component.scss
@@ -11,7 +11,6 @@ app-stat-card {
     border-radius: 4px;
     border-color: transparent;
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16), 0 0 0 1px rgba(0, 0, 0, 0.08);
-    cursor: pointer;
     width: 100%;
     height: 100%;
 

--- a/app/components/app-stat-card.component.scss
+++ b/app/components/app-stat-card.component.scss
@@ -1,114 +1,67 @@
 app-stat-card {
-  width: 100%;
-  height: 100%;
+    width: 100%;
+    height: 100%;
 }
 
 .app-stat-card {
-  background-color: #fff;
-  border-style: solid;
-  border-width: 1px;
-  border-left-width: 4px;
-  border-radius: 4px;
-  border-color: transparent;
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16), 0 0 0 1px rgba(0, 0, 0, 0.08);
-  cursor: pointer;
-  width: 100%;
-  height: 100%;
-
-  &__layout {
-    display: flex;
-    gap: 15px;
-  }
-
-  &__heading {
-    padding: 10px 15px;
-    border-bottom: 1px solid transparent;
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
-    height: 100%;
+    background-color: #fff;
+    border-style: solid;
+    border-width: 1px;
+    border-left-width: 4px;
+    border-radius: 4px;
+    border-color: transparent;
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16), 0 0 0 1px rgba(0, 0, 0, 0.08);
+    cursor: pointer;
     width: 100%;
-  }
+    height: 100%;
 
-  &__stat-num {
-    font-size: 25px;
-    font-weight: 700;
-    color: #565a5c;
-  }
+    &__layout {
+        display: flex;
+        gap: 15px;
+    }
 
-  &__title {
-    font-size: 14px;
-    font-weight: 700;
-    padding-bottom: 5px;
-    text-transform: uppercase;
-  }
+    &__heading {
+        padding: 10px 15px;
+        border-bottom: 1px solid transparent;
+        border-top-left-radius: 3px;
+        border-top-right-radius: 3px;
+        height: 100%;
+        width: 100%;
+    }
 
-  &__stat-icon {
-    color: #dddfeb;
-    font-size: 33px;
-    padding-top: 5px;
-  }
+    &__stat-num {
+        font-size: 25px;
+        font-weight: 700;
+        color: #565a5c;
+    }
 
-  &__stat-bar {
-    align-items: end;
-    display: flex;
-    justify-content: space-between;
-  }
+    &__title {
+        font-size: 14px;
+        font-weight: 700;
+        padding-bottom: 5px;
+        text-transform: uppercase;
+    }
 
-  &__size-30 {
-    font-size: 30px;
-  }
+    &__stat-icon {
+        color: #dddfeb;
+        font-size: 33px;
+        padding-top: 5px;
+    }
 
-  &__divider {
-    margin-bottom: 0;
-    margin-top: 0;
-    width: 95%;
-  }
+    &__stat-bar {
+        align-items: end;
+        display: flex;
+        justify-content: space-between;
+    }
+
+    &__size-30 {
+        font-size: 30px;
+    }
+
+    &__divider {
+        margin-bottom: 0;
+        margin-top: 0;
+        width: 95%;
+    }
 }
 
-// css for testing purposes
-
-.default {
-  color: #007be3;
-  border-left-color: #007be3;
-
-  &--selected {
-    color: #007be3;
-    border-color: #007be3;
-  }
-}
-
-.fusion-yellow {
-  color: #ffc533;
-  border-left-color: #ffc533;
-
-  &--selected {
-    border-color: #ffc533;
-  }
-}
-
-.fusion-teal {
-  color: #2ac3be;
-  border-left-color: #2ac3be;
-
-  &--selected {
-    border-color: #2ac3be;
-  }
-}
-
-.fusion-red {
-  color: #f2726f;
-  border-left-color: #f2726f;
-
-  &--selected {
-    border-color: #f2726f;
-  }
-}
-
-.fusion-purple {
-  color: #5d62b5;
-  border-left-color: #5d62b5;
-
-  &--selected {
-    border-color: #5d62b5;
-  }
-}

--- a/app/components/app-toggle-card.component.scss
+++ b/app/components/app-toggle-card.component.scss
@@ -5,11 +5,21 @@
 }
 
 .app-toggle-card {
+    background-color: #fff;
+    border-style: solid;
+    border-width: 1px;
+    border-left-width: 4px;
+    border-radius: 4px;
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16), 0 0 0 1px rgba(0, 0, 0, 0.08);
+    width: 100%;
+    height: 100%;
     cursor: default;
 
     &__sub-title {
         padding-right: 10px;
         font-size: 14px;
+        font-weight: 700;
+        color: #565a5c;
     }
 
     &__title {
@@ -93,8 +103,4 @@
 .toggle-error-red {
     color: red;
     border-color: red;
-}
-
-.clickable {
-    cursor: pointer;
 }

--- a/app/components/button-card/app-button-card.component.html
+++ b/app/components/button-card/app-button-card.component.html
@@ -21,23 +21,22 @@
                 </div>
         
                 <div ng-if="vm.isButtonVisible && vm.isRouting">
-                    <span class="app-button-card__message">{{vm.cardMessage}}</span> <a ui-sref="{{vm.route}}">{{vm.buttonText}}</a>
+                    <span class="app-button-card__message">{{vm.cardMessage}}</span> <a class="clickable" ui-sref="{{vm.route}}">{{vm.buttonText}}</a>
                 </div>
-      
-              <span ng-if="!vm.isRouting && vm.isButtonVisible && vm.theme">
-                  <button
-                      ng-click="vm.onButtonClick()"
-                      class="app-button-card__button"
-                      ng-class="vm.applyButtonClass()"
-                  >{{vm.buttonText}}</button>
-              </span>
-              <span ng-if="!vm.isRouting && vm.isButtonVisible && !vm.theme">
-                <button
-                    ng-click="vm.onButtonClick()"
-                    ng-style="vm.applyButtonColor()"
-                    class="app-button-card__button extend-otr-button"
-                >{{vm.buttonText}}</button>
-              </span>
+                <span ng-if="!vm.isRouting && vm.isButtonVisible && vm.theme">
+                    <button
+                        ng-click="vm.onButtonClick()"
+                        class="app-button-card__button"
+                        ng-class="vm.applyButtonClass()"
+                    >{{vm.buttonText}}</button>
+                </span>
+                <span ng-if="!vm.isRouting && vm.isButtonVisible && !vm.theme">
+                    <button
+                        ng-click="vm.onButtonClick()"
+                        ng-style="vm.applyButtonColor()"
+                        class="app-button-card__button extend-otr-button"
+                    >{{vm.buttonText}}</button>
+                </span>
             </div>
             <div>
                 <span

--- a/app/components/button-card/app-button-card.component.html
+++ b/app/components/button-card/app-button-card.component.html
@@ -7,8 +7,17 @@
     <div class="app-stat-card__heading">
         <div class="app-button-card__stat-bar">
             <div>
-                <div class="app-stat-card__title">
-                    {{ vm.cardTitle }}
+                <div class="app-button-card__title-layout">
+                    <div class="app-stat-card__title">
+                        {{ vm.cardTitle }}
+                    </div>
+                    <div class="app-toggle-card__tooltip" ng-if="vm.tooltipVisible">
+                        <i 
+                            class="fa fa-question-circle-o"
+                            uib-tooltip="{{vm.tooltipMessage}}"
+                            tooltip-class="app-toggle-card__uib-tooltip"
+                            tooltip-placement="{{vm.tooltipPlacement}}"></i>
+                    </div>
                 </div>
                 <div ng-if="!vm.statInfoToDisplay">
                     <i class="fa fa-spinner fa-pulse fa-lg"></i>

--- a/app/components/button-card/app-button-card.component.html
+++ b/app/components/button-card/app-button-card.component.html
@@ -1,0 +1,53 @@
+<div
+    class="app-stat-card"
+    ng-class="vm.applyThemeClass()"
+    ng-style="vm.applyCustomColor()"
+    ng-click="vm.onSelect()"
+>
+    <div class="app-stat-card__heading">
+        <div class="app-button-card__stat-bar">
+            <div>
+                <div class="app-stat-card__title">
+                    {{ vm.cardTitle }}
+                </div>
+                <div ng-if="!vm.statInfoToDisplay">
+                    <i class="fa fa-spinner fa-pulse fa-lg"></i>
+                </div>
+                <div
+                    ng-if="vm.statInfoToDisplay && !vm.isButtonVisible"
+                    class="app-stat-card__stat-num app-stat-card__clickable"
+                >
+                    {{ vm.statInfoToDisplay }}
+                </div>
+        
+                <div ng-if="vm.isButtonVisible && vm.isRouting">
+                    <span class="app-button-card__message">{{vm.cardMessage}}</span> <a ui-sref="{{vm.route}}">{{vm.buttonText}}</a>
+                </div>
+      
+              <span ng-if="!vm.isRouting && vm.isButtonVisible && vm.theme">
+                  <button
+                      ng-click="vm.onButtonClick()"
+                      class="app-button-card__button"
+                      ng-class="vm.applyButtonClass()"
+                  >{{vm.buttonText}}</button>
+              </span>
+              <span ng-if="!vm.isRouting && vm.isButtonVisible && !vm.theme">
+                <button
+                    ng-click="vm.onButtonClick()"
+                    ng-style="vm.applyButtonColor()"
+                    class="app-button-card__button extend-otr-button"
+                >{{vm.buttonText}}</button>
+              </span>
+            </div>
+            <div>
+                <span
+                    class="app-button-card__stat-icon"
+                    ng-if="vm.isIconShowing === true"
+                >
+                    <i ng-class="{{'vm.iconClass'}}"></i>
+                </span>
+            </div>
+        </div>
+    </div>
+</div>
+ 

--- a/app/components/button-card/app-button-card.component.ts
+++ b/app/components/button-card/app-button-card.component.ts
@@ -16,12 +16,15 @@ interface ButtonCardBindings {
     buttonText?: string;
     cardMessage?: string;
     isButtonVisible: boolean;
+    tooltipPlacement?: string;
+    tooltipMessage?: string;
+    tooltipVisible: boolean;
 }
 
 type Theme = 'fusion-yellow' | 'fusion-teal' | 'fusion-red' | 'fusion-purple' | 'default';
 
 class ButtonCard implements ButtonCardBindings {
-    //bindings
+    // card bindings
     theme?: Theme;
     color?: string;
     iconClass!: string;
@@ -36,6 +39,11 @@ class ButtonCard implements ButtonCardBindings {
     buttonText?: string;
     cardMessage?: string;
     isButtonVisible!: boolean;
+
+    // tooltip bindings
+    tooltipPlacement?: string;
+    tooltipMessage?: string;
+    tooltipVisible!: boolean;
 
     $onInit() {
         this.color = this.color ?? undefined;
@@ -117,7 +125,10 @@ const component = {
         route: '@',
         buttonText: '@',
         isButtonVisible: '<',
-        cardMessage: '@'
+        cardMessage: '@',
+        tooltipPlacement: '@',
+        tooltipMessage: '@',
+        tooltipVisible: '<'
     },
     controller: ButtonCard,
     controllerAs: 'vm'

--- a/app/components/button-card/app-button-card.component.ts
+++ b/app/components/button-card/app-button-card.component.ts
@@ -58,7 +58,7 @@ class ButtonCard implements ButtonCardBindings {
             if (!this.isButtonVisible) {
                 return this.isSelected
                     ? `${this.theme} ${this.theme}--selected clickable`
-                    : this.theme + ' ' + 'clickable';
+                    : `${this.theme} clickable`;
             }
             return this.isSelected ? `${this.theme} ${this.theme}--selected` : this.theme;
         } else {

--- a/app/components/button-card/app-button-card.component.ts
+++ b/app/components/button-card/app-button-card.component.ts
@@ -1,0 +1,118 @@
+import angular from 'angular';
+import template from './app-button-card.component.html';
+
+interface ButtonCardBindings {
+    theme?: string;
+    color?: string;
+    iconClass: string;
+    cardTitle: string;
+    onSelect: () => null;
+    statInfoToDisplay: string;
+    isSelected: boolean;
+    isIconShowing: boolean;
+    isRouting: boolean | null;
+    route?: string | null;
+    onButtonClick?: () => null;
+    buttonText?: string;
+    cardMessage?: string;
+    isButtonVisible: boolean;
+}
+
+type Theme = 'fusion-yellow' | 'fusion-teal' | 'fusion-red' | 'fusion-purple' | 'default';
+
+class ButtonCard implements ButtonCardBindings {
+    //bindings
+    theme?: Theme;
+    color?: string;
+    iconClass!: string;
+    cardTitle!: string;
+    onSelect!: () => null;
+    statInfoToDisplay!: string;
+    isSelected!: boolean;
+    isIconShowing!: boolean;
+    isRouting!: boolean | null;
+    onButtonClick?: () => null;
+    route?: string | null;
+    buttonText?: string;
+    cardMessage?: string;
+    isButtonVisible!: boolean;
+
+    $onInit() {
+        this.color = this.color ?? undefined;
+        this.theme = this.color ? undefined : this.theme ?? 'default';
+        this.iconClass = this.iconClass ?? 'fa fa-solid fa-info';
+        this.cardTitle = this.cardTitle ?? 'Card title';
+        this.statInfoToDisplay = this.statInfoToDisplay ?? '10';
+        this.isRouting = this.isRouting ?? null;
+        this.route = this.route ?? null;
+    }
+
+    applyThemeClass() {
+        const themeEnums: Theme[] = [
+            'fusion-yellow',
+            'fusion-teal',
+            'fusion-red',
+            'fusion-purple'
+        ];
+        if (this.theme && themeEnums.includes(this.theme)) {
+            return this.isSelected ? `${this.theme} ${this.theme}--selected` : this.theme;
+        } else {
+            return this.isSelected ? 'default default--selected' : 'default';
+        }
+    }
+
+    // color can be either HEX, RGBA (ex. rgb(0, 0, 0)), color names like yellow
+    applyCustomColor() {
+        if (this.color) {
+            return this.isSelected
+                ? { color: this.color, 'border-color': this.color }
+                : { color: this.color, 'border-left-color': this.color };
+        }
+    }
+
+    applyButtonClass() {
+        if (this.theme) {
+            return 'otr-button--' + this.theme;
+        }
+
+        if (this.color && !this.theme) {
+            return 'otr-button--dynamic';
+        }
+    }
+
+    applyButtonColor() {
+        if (this.color) {
+            return {
+                background: this.color,
+                color: '#fff'
+            };
+        }
+    }
+}
+
+const component = {
+    selector: 'appButtonCard',
+    template: template,
+    bindings: {
+        theme: '@',
+        color: '@',
+        iconClass: '@',
+        cardTitle: '@',
+        onSelect: '&',
+        statInfoToDisplay: '@',
+        isSelected: '<',
+        isIconShowing: '<',
+        isRouting: '<',
+        onButtonClick: '&',
+        route: '@',
+        buttonText: '@',
+        isButtonVisible: '<',
+        cardMessage: '@'
+    },
+    controller: ButtonCard,
+    controllerAs: 'vm'
+};
+
+angular.module('otr-ui-shared-components').component(component.selector, component);
+
+ButtonCard.$inject = [];

--- a/app/components/button-card/app-button-card.component.ts
+++ b/app/components/button-card/app-button-card.component.ts
@@ -55,8 +55,18 @@ class ButtonCard implements ButtonCardBindings {
             'fusion-purple'
         ];
         if (this.theme && themeEnums.includes(this.theme)) {
+            if (!this.isButtonVisible) {
+                return this.isSelected
+                    ? `${this.theme} ${this.theme}--selected clickable`
+                    : this.theme + ' ' + 'clickable';
+            }
             return this.isSelected ? `${this.theme} ${this.theme}--selected` : this.theme;
         } else {
+            if (!this.isButtonVisible) {
+                return this.isSelected
+                    ? 'default default--selected clickable'
+                    : 'default clickable';
+            }
             return this.isSelected ? 'default default--selected' : 'default';
         }
     }

--- a/app/components/credit-card-form/credit-card-form.component.html
+++ b/app/components/credit-card-form/credit-card-form.component.html
@@ -146,7 +146,7 @@
     >
         {{ vm.paymentErrorMessage }}
     </div>
-    <button type="submit" class="otr-button--primary block"
+    <button type="submit" class="otr-button--default block"
             data-ref="fight.book.new-card.verify-button"
             ng-disabled="vm.showLoading">
         Verify Card

--- a/app/components/stat-card/app-stat-card.component.html
+++ b/app/components/stat-card/app-stat-card.component.html
@@ -1,5 +1,5 @@
 <div
-  class="app-stat-card"
+  class="app-stat-card clickable"
   ng-class="vm.applyThemeClass()"
   ng-style="vm.applyCustomColor()"
   ng-click="vm.onSelect()"

--- a/app/components/toggle-card/app-toggle-card.component.html
+++ b/app/components/toggle-card/app-toggle-card.component.html
@@ -1,5 +1,5 @@
 <div
-    class="app-stat-card app-toggle-card"
+    class="app-toggle-card"
     ng-class="{
         'toggle-error-red': vm.isEnabled,
         'toggle-success-green': !vm.isEnabled
@@ -32,7 +32,7 @@
                         <i class="fa fa-spinner fa-pulse fa-lg"></i>
                     </div>
                     <div
-                        class="app-stat-card__stat-num app-toggle-card__sub-title"
+                        class="app-toggle-card__sub-title"
                     >
                         {{ vm.message }}
                     </div>

--- a/app/tests/manual/button-card.html
+++ b/app/tests/manual/button-card.html
@@ -1,0 +1,47 @@
+<div class="flex-center">
+    <div class="button-card__group">
+        <div class="button-card__control">
+            <app-button-card
+                theme="{{ vm.theme }}"
+                icon-class="{{ vm.iconClass }}"
+                card-title="{{ vm.cardTitle }}"
+                stat-info-to-display="{{ vm.statInfoToDisplay }}"
+                is-routing="vm.isRouting"
+                route="{{ vm.route }}"
+                is-selected="vm.statusToFilterOn === 'payment_plan_cases'"
+                on-select="vm.onSelectCard('payment_plan_cases')"
+                is-icon-showing="vm.isIconShowing"
+                is-button-visible="false"
+            ></app-button-card>
+        </div>
+        <div class="button-card__control-route">
+            <app-button-card
+                theme="{{ vm.theme }}"
+                icon-class="{{ vm.iconClass }}"
+                card-title="{{ vm.cardTitle }}"
+                stat-info-to-display="{{ vm.statInfoToDisplay }}"
+                is-routing="vm.isRouting"
+                route="{{ vm.route }}"
+                is-selected="false"
+                button-text="{{ vm.buttonText }}"
+                card-message="{{ vm.cardMessage }}"
+                on-select="vm.onSelectCard('payment_plan_cases')"
+                is-icon-showing="vm.isIconShowing"
+                is-button-visible="true"
+            ></app-button-card>
+        </div>
+        <div class="button-card__control">
+            <app-button-card
+                color="green"
+                icon-class="{{ vm.iconClass }}"
+                card-title="{{ vm.cardTitle }}"
+                stat-info-to-display="{{ vm.statInfoToDisplay }}"
+                is-routing="false"
+                is-icon-showing="vm.isIconShowing"
+                is-button-visible="true"
+                button-text="Turn on payment plans"
+                on-button-click="vm.onClick()"
+            ></app-button-card>
+        </div>
+    </div>
+</div>

--- a/app/tests/manual/button-card.html
+++ b/app/tests/manual/button-card.html
@@ -12,6 +12,9 @@
                 on-select="vm.onSelectCard('payment_plan_cases')"
                 is-icon-showing="vm.isIconShowing"
                 is-button-visible="false"
+                tooltip-visible="vm.tooltipVisible"
+                tooltip-placement="{{vm.tooltipPlacement}}"
+                tooltip-message="{{vm.tooltipMessage}}"
             ></app-button-card>
         </div>
         <div class="button-card__control-route">
@@ -28,6 +31,9 @@
                 on-select="vm.onSelectCard('payment_plan_cases')"
                 is-icon-showing="vm.isIconShowing"
                 is-button-visible="true"
+                tooltip-visible="vm.tooltipVisible"
+                tooltip-placement="{{vm.tooltipPlacement}}"
+                tooltip-message="{{vm.tooltipMessage}}"
             ></app-button-card>
         </div>
         <div class="button-card__control">

--- a/app/tests/manual/router.ts
+++ b/app/tests/manual/router.ts
@@ -230,6 +230,10 @@ angular
                                 vm.cardMessage =
                                     'Firms who accept payment plans see a 10-15% lift in bookings.';
                                 vm.statusToFilterOn = null;
+                                vm.tooltipVisible = true;
+                                vm.tooltipPlacement = 'bottom';
+                                vm.tooltipMessage =
+                                    'Accepting payment plans leads to more case bookings. Your account is experiencing a 7% increase in case bookings due to payment plans.';
                                 vm.onSelectCard = (status) => {
                                     if (vm.statusToFilterOn) {
                                         vm.statusToFilterOn = null;

--- a/app/tests/manual/router.ts
+++ b/app/tests/manual/router.ts
@@ -8,6 +8,7 @@ import statCardsTemplate from './stat-cards.html';
 import toggleCardsTemplate from './toggle-cards.html';
 import avatarFallbackTemplate from './avatars.html';
 import paymentLogosTemplate from './payment-logos.html';
+import buttonCardTemplate from './button-card.html';
 
 angular
     .module('otr-ui-shared-components')
@@ -204,6 +205,43 @@ angular
 
                                 vm.onError = (error) => {
                                     console.log('from test', error);
+                                };
+                            }
+                        }
+                    }
+                })
+                .state('button-card', {
+                    url: '/button-card',
+                    views: {
+                        '': {
+                            template: buttonCardTemplate,
+                            controllerAs: 'vm',
+                            controller: function () {
+                                let vm: any = this;
+                                vm.theme = 'fusion-teal';
+                                vm.iconClass = 'fa fa-solid fa-info';
+                                vm.isIconShowing = true;
+                                vm.cardTitle = 'Payment Plan Cases';
+                                vm.statInfoToDisplay = '45%';
+                                vm.isRouting = true;
+                                vm.route = 'payment-logos';
+                                vm.buttonText = 'Turn on payment plans.';
+                                vm.isButtonVisible = true;
+                                vm.cardMessage =
+                                    'Firms who accept payment plans see a 10-15% lift in bookings.';
+                                vm.statusToFilterOn = null;
+                                vm.onSelectCard = (status) => {
+                                    if (vm.statusToFilterOn) {
+                                        vm.statusToFilterOn = null;
+                                    } else {
+                                        vm.statusToFilterOn = status;
+                                    }
+
+                                    console.log(vm.statusToFilterOn);
+                                };
+
+                                vm.onClick = () => {
+                                    console.log('I have been clicked');
                                 };
                             }
                         }

--- a/index-test.html
+++ b/index-test.html
@@ -122,6 +122,30 @@
                 margin: 0 auto;
                 max-width: 530px;
             }
+
+            .button-card__group {
+                display: flex;
+                flex-direction: column;
+                margin-top: 25px;
+                gap: 20px;
+            }
+
+            .button-card__control-route {
+                height: 92px;
+                width: 100%;
+                max-width: 388px;
+            }
+
+            .button-card__control {
+                height: 90px;
+                width: 295px;
+            }
+
+            .flex-center {
+                display: flex;
+                justify-content: center;
+                height: 500px;
+            }
         </style>
         <div class="menu">
             <a ui-sref="courts">Courts</a>
@@ -132,6 +156,7 @@
             <a ui-sref="toggle-cards">Toggle Cards</a>
             <a ui-sref="avatars">Avatars</a>
             <a ui-sref="payment-logos">Payment</a>
+            <a ui-sref="button-card">Button Card</a>
         </div>
         <div ui-view></div>
     </body>

--- a/index-test.html
+++ b/index-test.html
@@ -96,6 +96,7 @@
             .section__toggle-card {
                 height: 100px;
                 max-width: 300px;
+                margin-left: 50px;
             }
         
             button {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@otr-app/ui-shared-components",
-  "version": "2.0.21-alpha",
+  "version": "2.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@otr-app/ui-shared-components",
-      "version": "2.0.21-alpha",
+      "version": "2.0.5",
       "license": "ISC",
       "devDependencies": {
         "@angular/cli": "^12.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otr-app/ui-shared-components",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Module for shared components across OTR sites",
   "files": [
     "/dist"


### PR DESCRIPTION
This PR will:

- Add new button card component with similar design to stat/toggle card components
- Move utility styles to global _vars.scss file
- Add minor fix for toggle card not applying correct style

Notes: 

- Since this is a UI-shared-component the card has 3 different states. All three states are fully customizable  
    1. first example shows a card with displayed stat info, the card is clickable
    2. second example shows card with a button that accepts a route in an ui-sref
    3. third example shows card with a generic button that can be clicked

![image](https://user-images.githubusercontent.com/82499628/210471639-98f5ae91-904d-49b6-bdef-fa129fccc148.png)
