### PR TITLE
Multi-Select adjustment

### DIFF
--- a/app/components/multi-select-dropdown/multi-select-dropdown.component.ts
+++ b/app/components/multi-select-dropdown/multi-select-dropdown.component.ts
@@ -30,7 +30,7 @@ class MultiSelectDropdown {
   public onOptionSelection(option) {
       const isOptionSelected = _.findIndex(
           this.selectedOptions,
-          (o) => o.id === option.id
+          (o) => o === option
       );
 
       /* 
@@ -50,7 +50,7 @@ class MultiSelectDropdown {
 
       // if findIndex returns -1 option is not in list
       if (isOptionSelected > -1) {
-          _.remove(this.selectedOptions, (o) => o.id === option.id);
+          _.remove(this.selectedOptions, (o) => o === option);
           this.setSmartButtonText(option);
       } else {
           this.selectedOptions.push(option);
@@ -75,7 +75,7 @@ class MultiSelectDropdown {
   public isOptionSelected(option: DropdownDataObj): boolean {
       const isOptionSelected = _.findIndex(
           this.selectedOptions,
-          (o) => o.id === option.id
+          (o) => o === option
       );
 
       // if findIndex returns -1 option is not in list

--- a/app/components/multi-select-dropdown/multi-select-dropdown.component.ts
+++ b/app/components/multi-select-dropdown/multi-select-dropdown.component.ts
@@ -30,7 +30,7 @@ class MultiSelectDropdown {
   public onOptionSelection(option) {
       const isOptionSelected = _.findIndex(
           this.selectedOptions,
-          (o) => o.label === option.label
+          (o) => o.id === option.id
       );
 
       /* 
@@ -50,7 +50,7 @@ class MultiSelectDropdown {
 
       // if findIndex returns -1 option is not in list
       if (isOptionSelected > -1) {
-          _.remove(this.selectedOptions, (o) => o.label === option.label);
+          _.remove(this.selectedOptions, (o) => o.id === option.id);
           this.setSmartButtonText(option);
       } else {
           this.selectedOptions.push(option);
@@ -75,7 +75,7 @@ class MultiSelectDropdown {
   public isOptionSelected(option: DropdownDataObj): boolean {
       const isOptionSelected = _.findIndex(
           this.selectedOptions,
-          (o) => o.label === option.label
+          (o) => o.id === option.id
       );
 
       // if findIndex returns -1 option is not in list

--- a/app/tests/manual/router.ts
+++ b/app/tests/manual/router.ts
@@ -283,21 +283,25 @@ angular
                                         group: 'Regions',
                                         set: [
                                             {
+                                                id: 13,
                                                 name: 'WEST',
                                                 value: 'WEST',
                                                 label: 'West'
                                             },
                                             {
+                                                id: 14,
                                                 name: 'EAST',
                                                 value: 'EAST',
                                                 label: 'East'
                                             },
                                             {
+                                                id: 15,
                                                 name: 'SOUTH',
                                                 value: 'SOUTH',
                                                 label: 'South'
                                             },
                                             {
+                                                id: 16,
                                                 name: 'MIDDLE',
                                                 value: 'MIDDLE',
                                                 label: 'Mid'
@@ -324,6 +328,12 @@ angular
                                                 name: 'ARIZONA',
                                                 value: 'AZ',
                                                 label: 'Arizona'
+                                            },
+                                            {
+                                                id: 4,
+                                                name: 'WEST',
+                                                value: 'WA',
+                                                label: 'West'
                                             }
                                             // Add more Western states here
                                         ]

--- a/app/tests/manual/router.ts
+++ b/app/tests/manual/router.ts
@@ -283,25 +283,21 @@ angular
                                         group: 'Regions',
                                         set: [
                                             {
-                                                id: 13,
                                                 name: 'WEST',
                                                 value: 'WEST',
                                                 label: 'West'
                                             },
                                             {
-                                                id: 14,
                                                 name: 'EAST',
                                                 value: 'EAST',
                                                 label: 'East'
                                             },
                                             {
-                                                id: 15,
                                                 name: 'SOUTH',
                                                 value: 'SOUTH',
                                                 label: 'South'
                                             },
                                             {
-                                                id: 16,
                                                 name: 'MIDDLE',
                                                 value: 'MIDDLE',
                                                 label: 'Mid'

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,8 @@
         "angular-animate": ">= 1.4.9 || <= 1.6.9",
         "angular-credit-cards": "3.1.7",
         "angular-stripe": "5.0.0",
+        "angular-ui-bootstrap": "2.5.0",
         "angular-validator": "1.2.9",
-        "angularjs-ui-bootstrap": "2.5.0",
         "bootstrap": "~3.3.2",
         "fuse.js": ">= 6.4.6 || < 7.0.0",
         "lodash": ">= 4.17.21 || < 5.0.0",
@@ -1217,6 +1217,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/angular-ui-bootstrap": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.0.tgz",
+      "integrity": "sha512-XcIAGHEUuTBJRnR//mJ2UpbOo//k56Yi+cREn+1O9wSF1rgRY1xZ00mhL3+elrIxaalcO3Kc/L2dZshtrafeGg==",
+      "peer": true
+    },
     "node_modules/angular-validator": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/angular-validator/-/angular-validator-1.2.9.tgz",
@@ -2333,15 +2339,6 @@
       "peer": true,
       "bin": {
         "which": "bin/which"
-      }
-    },
-    "node_modules/angularjs-ui-bootstrap": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/angularjs-ui-bootstrap/-/angularjs-ui-bootstrap-2.5.0.tgz",
-      "integrity": "sha512-VfoZtAie9faJDse2UeEING/wIeCJwHOS2CvIDFSfL85snffi/vdeDlZ0GYz2n3ZeNtgwJrEY8fP0rDLMSSKgXA==",
-      "peer": true,
-      "peerDependencies": {
-        "angular": ">= 1.4.0-beta.0 || >= 1.5.0-beta.0"
       }
     },
     "node_modules/ansi-align": {
@@ -17747,6 +17744,12 @@
         }
       }
     },
+    "angular-ui-bootstrap": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.0.tgz",
+      "integrity": "sha512-XcIAGHEUuTBJRnR//mJ2UpbOo//k56Yi+cREn+1O9wSF1rgRY1xZ00mhL3+elrIxaalcO3Kc/L2dZshtrafeGg==",
+      "peer": true
+    },
     "angular-validator": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/angular-validator/-/angular-validator-1.2.9.tgz",
@@ -18653,13 +18656,6 @@
           "peer": true
         }
       }
-    },
-    "angularjs-ui-bootstrap": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/angularjs-ui-bootstrap/-/angularjs-ui-bootstrap-2.5.0.tgz",
-      "integrity": "sha512-VfoZtAie9faJDse2UeEING/wIeCJwHOS2CvIDFSfL85snffi/vdeDlZ0GYz2n3ZeNtgwJrEY8fP0rDLMSSKgXA==",
-      "peer": true,
-      "requires": {}
     },
     "ansi-align": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@otr-app/ui-shared-components",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@otr-app/ui-shared-components",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "ISC",
       "devDependencies": {
         "@angular/cli": "^12.2.1",
@@ -36,8 +36,8 @@
         "angular-animate": ">= 1.4.9 || <= 1.6.9",
         "angular-credit-cards": "3.1.7",
         "angular-stripe": "5.0.0",
-        "angular-ui-bootstrap": "2.5.0",
         "angular-validator": "1.2.9",
+        "angularjs-ui-bootstrap": "2.5.0",
         "bootstrap": "~3.3.2",
         "fuse.js": ">= 6.4.6 || < 7.0.0",
         "lodash": ">= 4.17.21 || < 5.0.0",
@@ -1217,12 +1217,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/angular-ui-bootstrap": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.0.tgz",
-      "integrity": "sha512-XcIAGHEUuTBJRnR//mJ2UpbOo//k56Yi+cREn+1O9wSF1rgRY1xZ00mhL3+elrIxaalcO3Kc/L2dZshtrafeGg==",
-      "peer": true
-    },
     "node_modules/angular-validator": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/angular-validator/-/angular-validator-1.2.9.tgz",
@@ -2339,6 +2333,15 @@
       "peer": true,
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/angularjs-ui-bootstrap": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/angularjs-ui-bootstrap/-/angularjs-ui-bootstrap-2.5.0.tgz",
+      "integrity": "sha512-VfoZtAie9faJDse2UeEING/wIeCJwHOS2CvIDFSfL85snffi/vdeDlZ0GYz2n3ZeNtgwJrEY8fP0rDLMSSKgXA==",
+      "peer": true,
+      "peerDependencies": {
+        "angular": ">= 1.4.0-beta.0 || >= 1.5.0-beta.0"
       }
     },
     "node_modules/ansi-align": {
@@ -17744,12 +17747,6 @@
         }
       }
     },
-    "angular-ui-bootstrap": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.0.tgz",
-      "integrity": "sha512-XcIAGHEUuTBJRnR//mJ2UpbOo//k56Yi+cREn+1O9wSF1rgRY1xZ00mhL3+elrIxaalcO3Kc/L2dZshtrafeGg==",
-      "peer": true
-    },
     "angular-validator": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/angular-validator/-/angular-validator-1.2.9.tgz",
@@ -18656,6 +18653,13 @@
           "peer": true
         }
       }
+    },
+    "angularjs-ui-bootstrap": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/angularjs-ui-bootstrap/-/angularjs-ui-bootstrap-2.5.0.tgz",
+      "integrity": "sha512-VfoZtAie9faJDse2UeEING/wIeCJwHOS2CvIDFSfL85snffi/vdeDlZ0GYz2n3ZeNtgwJrEY8fP0rDLMSSKgXA==",
+      "peer": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@otr-app/ui-shared-components",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@otr-app/ui-shared-components",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "ISC",
       "devDependencies": {
         "@angular/cli": "^12.2.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "angular-credit-cards": "3.1.7",
     "angular-stripe": "5.0.0",
     "angular-ui-bootstrap": "2.5.0",
+    "angularjs-ui-bootstrap": "2.5.0",
     "angular-validator": "1.2.9",
     "bootstrap": "~3.3.2",
     "fuse.js": ">= 6.4.6 || < 7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otr-app/ui-shared-components",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Module for shared components across OTR sites",
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "angular-credit-cards": "3.1.7",
     "angular-stripe": "5.0.0",
     "angular-ui-bootstrap": "2.5.0",
-    "angularjs-ui-bootstrap": "2.5.0",
     "angular-validator": "1.2.9",
     "bootstrap": "~3.3.2",
     "fuse.js": ">= 6.4.6 || < 7.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,7 +76,7 @@ module.exports = (env, argv) => {
             // serve index.html for all 404
             historyApiFallback: true,
             compress: true,
-            port: 8000,
+            port: 8889,
             hot: true,
             open: true
         },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,7 +76,7 @@ module.exports = (env, argv) => {
             // serve index.html for all 404
             historyApiFallback: true,
             compress: true,
-            port: 8889,
+            port: 8000,
             hot: true,
             open: true
         },


### PR DESCRIPTION
Hit a snag with the grouped options version where if two options have the same label [for instance UNCONFIRMED case status category and UNCONFIRMED case status] the ui will not allow you to select both, but will show both as selected when one is clicked.

This PR updates the multi-select to compare the whole obj, instead of a label.