### PR TITLE
Modify toggle card to match UI of stat card when backend call fails

### DIFF
--- a/app/components/app-stat-card.component.scss
+++ b/app/components/app-stat-card.component.scss
@@ -28,6 +28,14 @@ app-stat-card {
         width: 100%;
     }
 
+    &__heading-alt {
+        padding: 10px 15px;
+        border-bottom: 1px solid transparent;
+        border-top-left-radius: 3px;
+        border-top-right-radius: 3px;
+        width: 100%;
+    }
+
     &__stat-num {
         font-size: 25px;
         font-weight: 700;

--- a/app/components/app-toggle-card.component.scss
+++ b/app/components/app-toggle-card.component.scss
@@ -37,7 +37,12 @@
         font-weight: 700;
         padding-bottom: 5px;
         text-transform: uppercase;
-        color: black !important;
+        color: black;
+
+        &-alt {
+            font-size: 14px;
+            color: green;
+        }
     }
 
     &__layout {

--- a/app/components/toggle-card/app-toggle-card.component.html
+++ b/app/components/toggle-card/app-toggle-card.component.html
@@ -5,13 +5,21 @@
         'toggle-success-green': !vm.isEnabled
         }"
 >
-    <div class="app-stat-card__heading app-toggle-card__heading">
+    <div 
+        class="app-toggle-card__heading"
+        ng-class="{'app-stat-card__heading-alt': vm.isEnabled === null,
+                    'app-stat-card__heading': vm.isEnabled !== null
+                }"
+    >
         <div 
             class="app-toggle-card__layout"
             ng-switch
             on="vm.isEnabled"
         >
-            <div class="app-toggle-card__title">
+            <div 
+                class="app-toggle-card__title"
+                ng-class="{'app-toggle-card__title-alt': vm.isEnabled === null}"
+            >
                 {{ vm.cardTitle }}
             </div>
             <div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otr-app/ui-shared-components",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Module for shared components across OTR sites",
   "files": [
     "/dist"


### PR DESCRIPTION
This PR will:

- Modify the UI of the toggle card to match the UI style of stat cards when backend call fails.